### PR TITLE
refactor: update latest Go versions + tools in flake.nix

### DIFF
--- a/.anvil.lock
+++ b/.anvil.lock
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2024-02-22T13:17:03.572759162Z",
-  "version": "1.2.8",
+  "generated_at": "2024-03-13T11:43:36.214055344Z",
+  "version": "1.2.10",
   "files": [
     {
       "path": ".editorconfig"

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
 
       packages = forAllSystems
         ({ pkgs }: {
-          default = pkgs.buildGo121Module
+          default = pkgs.buildGo122Module
             {
               name = "cmd";
               src = gitignore.lib.gitignoreSource ./.;
@@ -42,11 +42,12 @@
             shellHook = "exec zsh && echo Welcome to your Go dev shell!";
             packages = with pkgs; [
               gnumake
-              zsh
               go-mockery
+              go
+              gofumpt
               golangci-lint
-              go_1_21
               just
+              zsh
             ];
           };
         });


### PR DESCRIPTION
Updates `flake.nix` to use the latest Go version