### PR TITLE
feat: add support for uploading media in messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Telegram GitHub Action
 
-**Send (text) messages to a Telegram chat from GitHub Actions.**
+**Send messages and media to a Telegram chat from GitHub Actions.**
 
 [![GitHub release](https://img.shields.io/github/release/cbrgm/telegram-github-action.svg)](https://github.com/cbrgm/telegram-github-action)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cbrgm/telegram-github-action)](https://goreportcard.com/report/github.com/cbrgm/telegram-github-action)
@@ -10,12 +10,14 @@
 
 ## Inputs
 
-- `token`: **Required** - Telegram bot's authorization token. Use GitHub secrets.
+- `token`: **Required** - Telegram bot’s authorization token. Use GitHub secrets.
 - `to`: **Required** - Unique identifier or username of the target Telegram chat.
 - `thread-id`: (Optional) Thread identifier in a Telegram supergroup.
     - The message won’t be sent if `to` isn’t a supergroup and `thread-id` is set.
-- `message`: Optional - Text message to send. If omitted, bot's information is fetched.
+- `message`: Optional - Text message to send. Used as caption when `media` is provided.
 - `parse-mode`: Optional - Mode for parsing text entities (`markdown` or `html`).
+- `media`: Optional - Media to send. Can be a local file path, an HTTP URL, or a Telegram `file_id`.
+- `media-type`: Optional - Type of media. One of: `photo`, `video`, `audio`, `document`, `animation`, `voice`, `sticker`. Required when `media` is set.
 - `disable-web-page-preview`: Optional - Disables link previews.
 - `disable-notification`: Optional - Sends message silently.
 - `protect-content`: Optional - Protects message content from forwarding/saving.
@@ -99,6 +101,122 @@ jobs:
             Check it out: ${{ github.event.release.html_url }}j
 
 ```
+
+### Example Workflow: Send a Photo via URL
+
+```yaml
+name: Send Photo
+
+on: [push]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Photo to Telegram
+        uses: cbrgm/telegram-github-action@v1
+        with:
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          to: ${{ secrets.TELEGRAM_CHAT_ID }}
+          media: "https://example.com/build-status.png"
+          media-type: "photo"
+          message: "Latest build status for ${{ github.repository }}"
+```
+
+### Example Workflow: Upload a Local File
+
+This workflow uploads a build artifact (e.g. a PDF report or binary) directly from the runner filesystem.
+
+```yaml
+name: Upload Build Report
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+
+jobs:
+  send-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate report
+        run: echo "Build completed at $(date)" > report.txt
+
+      - name: Send Report to Telegram
+        uses: cbrgm/telegram-github-action@v1
+        with:
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          to: ${{ secrets.TELEGRAM_CHAT_ID }}
+          media: "report.txt"
+          media-type: "document"
+          message: "Build report attached"
+```
+
+### Example Workflow: Send a Video
+
+```yaml
+name: Send Demo Video
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Video to Telegram
+        uses: cbrgm/telegram-github-action@v1
+        with:
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          to: ${{ secrets.TELEGRAM_CHAT_ID }}
+          media: "https://example.com/demo.mp4"
+          media-type: "video"
+          message: "Demo video for release ${{ github.event.release.tag_name }}"
+```
+
+### Example Workflow: Send an Animation (GIF)
+
+```yaml
+name: CI Status GIF
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Welcome GIF
+        uses: cbrgm/telegram-github-action@v1
+        with:
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          to: ${{ secrets.TELEGRAM_CHAT_ID }}
+          media: "https://example.com/welcome.gif"
+          media-type: "animation"
+          message: "New PR opened by ${{ github.actor }}"
+```
+
+### Supported Media Types
+
+| Type | API Method | Description | Max Size |
+|------|-----------|-------------|----------|
+| `photo` | sendPhoto | Images (JPEG, PNG, etc.) | 10 MB |
+| `video` | sendVideo | Video files (MPEG4 recommended) | 50 MB |
+| `audio` | sendAudio | Audio for music players (MP3, M4A) | 50 MB |
+| `document` | sendDocument | Any file type | 50 MB |
+| `animation` | sendAnimation | GIFs or H.264 videos without sound | 50 MB |
+| `voice` | sendVoice | Voice messages (OGG/OPUS, MP3, M4A) | 50 MB |
+| `sticker` | sendSticker | Stickers (WEBP, TGS, WEBM). No caption support. | 50 MB |
+
+The `media` input accepts three formats:
+- **Local file path**: Uploads the file from the runner (e.g. `./artifacts/screenshot.png`)
+- **HTTP URL**: Telegram downloads the file from the URL (e.g. `https://example.com/image.jpg`)
+- **Telegram file_id**: Resends a file already on Telegram's servers (e.g. `AgACAgIAAxk...`)
 
 ### Creating a Telegram Bot and Obtaining a Token
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Telegram Message Action'
-description: 'Send messages to a Telegram chat from GitHub Actions'
+description: 'Send messages and media to a Telegram chat from GitHub Actions'
 author: 'cbrgm'
 
 inputs:
@@ -13,12 +13,18 @@ inputs:
     description: "For supergroups. Thread identifier."
     required: false
   message:
-    description: 'The message to send'
+    description: 'The message to send (used as caption when media is provided)'
     required: false
   parse-mode:
-    description: 'Mode for parsing entities in the message text'
+    description: 'Mode for parsing entities in the message text or caption'
     required: false
     default: 'markdown'
+  media:
+    description: 'Media to send. Can be a local file path, an HTTP URL, or a Telegram file_id'
+    required: false
+  media-type:
+    description: 'Type of media to send. One of: photo, video, audio, document, animation, voice, sticker'
+    required: false
   disable-web-page-preview:
     description: 'Disables link previews for links in this message'
     required: false
@@ -48,6 +54,10 @@ runs:
     - ${{ inputs.parse-mode }}
     - --thread-id
     - ${{ inputs.thread-id }}
+    - --media
+    - ${{ inputs.media }}
+    - --media-type
+    - ${{ inputs.media-type }}
     - --to=${{ inputs.to }}
     - --disable-web-page-preview=${{ inputs.disable-web-page-preview }}
     - --disable-notification=${{ inputs.disable-notification }}

--- a/cmd/telegram-github-action/main.go
+++ b/cmd/telegram-github-action/main.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime/multipart"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -16,15 +18,13 @@ import (
 	"github.com/alexflint/go-arg"
 )
 
-// Global variables for application metadata.
 var (
-	Version   string              // Version of the application.
-	Revision  string              // Revision or Commit this binary was built from.
-	GoVersion = runtime.Version() // GoVersion running this binary.
-	StartTime = time.Now()        // StartTime of the application.
+	Version   string
+	Revision  string
+	GoVersion = runtime.Version()
+	StartTime = time.Now()
 )
 
-// TelegramMessage represents the payload for sending messages via the Telegram API.
 type TelegramMessage struct {
 	ChatID                int64  `json:"chat_id"`
 	MessageThreadID       *int64 `json:"message_thread_id,omitempty"`
@@ -35,22 +35,42 @@ type TelegramMessage struct {
 	ProtectContent        bool   `json:"protect_content,omitempty"`
 }
 
-// ActionInputs holds the required environment variables for the action.
 type ActionInputs struct {
 	Token                 string `arg:"--token,env:TELEGRAM_TOKEN,required"`
 	To                    string `arg:"--to,env:TELEGRAM_TO,required"`
 	MessageThreadID       string `arg:"--thread-id,env:TELEGRAM_THREAD_ID"`
 	Message               string `arg:"--message,env:MESSAGE"`
 	ParseMode             string `arg:"--parse-mode,env:PARSE_MODE"`
+	Media                 string `arg:"--media,env:TELEGRAM_MEDIA"`
+	MediaType             string `arg:"--media-type,env:TELEGRAM_MEDIA_TYPE"`
 	DisableWebPagePreview bool   `arg:"--disable-web-page-preview,env:DISABLE_WEB_PAGE_PREVIEW"`
 	DisableNotification   bool   `arg:"--disable-notification,env:DISABLE_NOTIFICATION"`
 	ProtectContent        bool   `arg:"--protect-content,env:PROTECT_CONTENT"`
 	DryRun                bool   `arg:"--dry-run" help:"If set, do not send a real message but print the details instead"`
 }
 
-// Version returns a formatted string with application version details.
 func (ActionInputs) Version() string {
 	return fmt.Sprintf("Version: %s %s\nBuildTime: %s\n%s\n", Revision, Version, StartTime.Format("2006-01-02"), GoVersion)
+}
+
+var validMediaTypes = map[string]string{
+	"photo":     "sendPhoto",
+	"video":     "sendVideo",
+	"audio":     "sendAudio",
+	"document":  "sendDocument",
+	"animation": "sendAnimation",
+	"voice":     "sendVoice",
+	"sticker":   "sendSticker",
+}
+
+var mediaFieldName = map[string]string{
+	"photo":     "photo",
+	"video":     "video",
+	"audio":     "audio",
+	"document":  "document",
+	"animation": "animation",
+	"voice":     "voice",
+	"sticker":   "sticker",
 }
 
 func main() {
@@ -60,21 +80,18 @@ func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	logger.Info("Starting Telegram GitHub Action")
 
-	// Validate ParseMode
 	if args.ParseMode != "" && args.ParseMode != "markdown" && args.ParseMode != "html" {
 		logger.Error("Invalid ParseMode", slog.String("ParseMode", args.ParseMode))
 		os.Exit(1)
 	}
 
-	// Convert args.To to int64 to handle negative chat IDs
 	toInt, err := strconv.ParseInt(args.To, 10, 64)
 	if err != nil {
 		logger.Error("Invalid chat ID", slog.String("ChatID", args.To), slog.Any("error", err))
 		os.Exit(1)
 	}
 
-	// Process MessageThreadID if it's not empty or just whitespace
-	var threadID *int64 = nil
+	var threadID *int64
 	if trimmedThreadID := strings.TrimSpace(args.MessageThreadID); trimmedThreadID != "" {
 		parsedThreadID, err := strconv.ParseInt(trimmedThreadID, 10, 64)
 		if err != nil {
@@ -84,21 +101,37 @@ func main() {
 		threadID = &parsedThreadID
 	}
 
-	messagePayload := TelegramMessage{
-		ChatID:                toInt,
-		MessageThreadID:       threadID,
-		Text:                  args.Message,
-		ParseMode:             args.ParseMode,
-		DisableWebPagePreview: args.DisableWebPagePreview,
-		DisableNotification:   args.DisableNotification,
-		ProtectContent:        args.ProtectContent,
+	media := strings.TrimSpace(args.Media)
+	mediaType := strings.TrimSpace(args.MediaType)
+
+	if media != "" && mediaType == "" {
+		logger.Error("media-type is required when media is provided")
+		os.Exit(1)
 	}
 
-	// Dry-run check
+	if mediaType != "" && media == "" {
+		logger.Error("media is required when media-type is provided")
+		os.Exit(1)
+	}
+
+	if mediaType != "" {
+		if _, ok := validMediaTypes[mediaType]; !ok {
+			logger.Error("Invalid media-type", slog.String("media-type", mediaType))
+			os.Exit(1)
+		}
+	}
+
+	if media == "" && args.Message == "" {
+		logger.Error("Either message or media must be provided")
+		os.Exit(1)
+	}
+
 	if args.DryRun {
 		logger.Info("Dry run enabled, message will not be sent",
 			slog.String("Message", args.Message),
 			slog.String("ParseMode", args.ParseMode),
+			slog.String("Media", media),
+			slog.String("MediaType", mediaType),
 			slog.Bool("DisableWebPagePreview", args.DisableWebPagePreview),
 			slog.Bool("DisableNotification", args.DisableNotification),
 			slog.Bool("ProtectContent", args.ProtectContent),
@@ -106,16 +139,185 @@ func main() {
 		return
 	}
 
-	// Actual API call if not in dry run
-	logger.Info("Sending custom message")
-	if err := callTelegramAPI(logger, args.Token, "sendMessage", messagePayload); err != nil {
-		logger.Error("Error sending Telegram message", slog.Any("error", err))
-		os.Exit(1)
+	if media != "" {
+		logger.Info("Sending media message", slog.String("media-type", mediaType))
+		err := sendMedia(logger, args.Token, toInt, threadID, media, mediaType, args.Message, args.ParseMode, args.DisableNotification, args.ProtectContent)
+		if err != nil {
+			logger.Error("Error sending media", slog.Any("error", err))
+			os.Exit(1)
+		}
+		logger.Info("Media sent successfully")
+	} else {
+		messagePayload := TelegramMessage{
+			ChatID:                toInt,
+			MessageThreadID:       threadID,
+			Text:                  args.Message,
+			ParseMode:             args.ParseMode,
+			DisableWebPagePreview: args.DisableWebPagePreview,
+			DisableNotification:   args.DisableNotification,
+			ProtectContent:        args.ProtectContent,
+		}
+
+		logger.Info("Sending text message")
+		if err := callTelegramAPI(logger, args.Token, "sendMessage", messagePayload); err != nil {
+			logger.Error("Error sending Telegram message", slog.Any("error", err))
+			os.Exit(1)
+		}
+		logger.Info("Message sent successfully")
 	}
-	logger.Info("Message sent successfully")
 }
 
-// callTelegramAPI handles calling the Telegram Bot API with the specified method and payload.
+func sendMedia(logger *slog.Logger, token string, chatID int64, threadID *int64, media, mediaType, caption, parseMode string, disableNotification, protectContent bool) error {
+	method := validMediaTypes[mediaType]
+	fieldName := mediaFieldName[mediaType]
+	apiURL := fmt.Sprintf("https://api.telegram.org/bot%s/%s", token, method)
+
+	isFilePath := isLocalFile(media)
+
+	if isFilePath {
+		return sendMediaMultipart(logger, apiURL, chatID, threadID, media, fieldName, mediaType, caption, parseMode, disableNotification, protectContent)
+	}
+
+	return sendMediaJSON(logger, apiURL, chatID, threadID, media, fieldName, mediaType, caption, parseMode, disableNotification, protectContent)
+}
+
+func isLocalFile(media string) bool {
+	if strings.HasPrefix(media, "http://") || strings.HasPrefix(media, "https://") {
+		return false
+	}
+	_, err := os.Stat(media)
+	return err == nil
+}
+
+func sendMediaJSON(logger *slog.Logger, apiURL string, chatID int64, threadID *int64, media, fieldName, mediaType, caption, parseMode string, disableNotification, protectContent bool) error {
+	payload := map[string]any{
+		"chat_id": chatID,
+		fieldName: media,
+	}
+
+	if threadID != nil {
+		payload["message_thread_id"] = *threadID
+	}
+
+	if caption != "" && mediaType != "sticker" {
+		payload["caption"] = caption
+	}
+	if parseMode != "" && mediaType != "sticker" {
+		payload["parse_mode"] = parseMode
+	}
+	if disableNotification {
+		payload["disable_notification"] = true
+	}
+	if protectContent {
+		payload["protect_content"] = true
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("error marshaling payload: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	return doRequest(logger, req)
+}
+
+func sendMediaMultipart(logger *slog.Logger, apiURL string, chatID int64, threadID *int64, filePath, fieldName, mediaType, caption, parseMode string, disableNotification, protectContent bool) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("error opening file %s: %w", filePath, err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			logger.Warn("Error closing file", slog.Any("error", err))
+		}
+	}()
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	part, err := writer.CreateFormFile(fieldName, filepath.Base(filePath))
+	if err != nil {
+		return fmt.Errorf("error creating form file: %w", err)
+	}
+
+	if _, err = io.Copy(part, file); err != nil {
+		return fmt.Errorf("error copying file data: %w", err)
+	}
+
+	if err := writer.WriteField("chat_id", strconv.FormatInt(chatID, 10)); err != nil {
+		return fmt.Errorf("error writing chat_id field: %w", err)
+	}
+
+	if threadID != nil {
+		if err := writer.WriteField("message_thread_id", strconv.FormatInt(*threadID, 10)); err != nil {
+			return fmt.Errorf("error writing message_thread_id field: %w", err)
+		}
+	}
+
+	if caption != "" && mediaType != "sticker" {
+		if err := writer.WriteField("caption", caption); err != nil {
+			return fmt.Errorf("error writing caption field: %w", err)
+		}
+	}
+	if parseMode != "" && mediaType != "sticker" {
+		if err := writer.WriteField("parse_mode", parseMode); err != nil {
+			return fmt.Errorf("error writing parse_mode field: %w", err)
+		}
+	}
+	if disableNotification {
+		if err := writer.WriteField("disable_notification", "true"); err != nil {
+			return fmt.Errorf("error writing disable_notification field: %w", err)
+		}
+	}
+	if protectContent {
+		if err := writer.WriteField("protect_content", "true"); err != nil {
+			return fmt.Errorf("error writing protect_content field: %w", err)
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("error closing multipart writer: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", apiURL, body)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	return doRequest(logger, req)
+}
+
+func doRequest(logger *slog.Logger, req *http.Request) error {
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error sending request to Telegram API: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Warn("Error closing response body", slog.Any("error", err))
+		}
+	}()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("received non-OK response from Telegram API: %s, body: %s", resp.Status, string(responseBody))
+	}
+
+	logger.Info("API response", slog.String("response", string(responseBody)))
+	return nil
+}
+
 func callTelegramAPI(logger *slog.Logger, token, method string, payload any) error {
 	url := fmt.Sprintf("https://api.telegram.org/bot%s/%s", token, method)
 
@@ -126,8 +328,6 @@ func callTelegramAPI(logger *slog.Logger, token, method string, payload any) err
 		if err != nil {
 			return fmt.Errorf("error marshaling payload: %w", err)
 		}
-	} else {
-		body = nil
 	}
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
@@ -136,26 +336,5 @@ func callTelegramAPI(logger *slog.Logger, token, method string, payload any) err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("error sending request to Telegram API: %w", err)
-	}
-	defer func() {
-		if err = resp.Body.Close(); err != nil {
-			logger.Warn("Error closing response body", slog.Any("error", err))
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("received non-OK response from Telegram API: %s", resp.Status)
-	}
-
-	responseBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("error reading response body: %w", err)
-	}
-
-	logger.Info("API response", slog.String("method", method), slog.String("response", string(responseBody)))
-	return nil
+	return doRequest(logger, req)
 }

--- a/cmd/telegram-github-action/main_test.go
+++ b/cmd/telegram-github-action/main_test.go
@@ -415,11 +415,6 @@ func TestCallTelegramAPI_SendMessage(t *testing.T) {
 		ParseMode: "markdown",
 	}
 
-	serverURL := strings.TrimPrefix(server.URL, "http://")
-	originalURL := "https://api.telegram.org/bot"
-	_ = originalURL
-	_ = serverURL
-
 	err := callTelegramAPI(logger, "testtoken", "sendMessage", msg)
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {

--- a/cmd/telegram-github-action/main_test.go
+++ b/cmd/telegram-github-action/main_test.go
@@ -1,0 +1,603 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsLocalFile(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test-media-*.jpg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"HTTP URL", "http://example.com/image.jpg", false},
+		{"HTTPS URL", "https://example.com/image.jpg", false},
+		{"File ID", "AgACAgIAAxkBAAI", false},
+		{"Local file", tmpFile.Name(), true},
+		{"Non-existent file", "/nonexistent/path/file.jpg", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isLocalFile(tt.input)
+			if result != tt.expected {
+				t.Errorf("isLocalFile(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSendMediaJSON_Photo(t *testing.T) {
+	var receivedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true,"result":{"message_id":123}}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	err := sendMediaJSON(logger, server.URL, 12345, nil, "https://example.com/photo.jpg", "photo", "photo", "Test caption", "markdown", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedBody["chat_id"].(float64) != 12345 {
+		t.Errorf("expected chat_id 12345, got %v", receivedBody["chat_id"])
+	}
+	if receivedBody["photo"] != "https://example.com/photo.jpg" {
+		t.Errorf("expected photo URL, got %v", receivedBody["photo"])
+	}
+	if receivedBody["caption"] != "Test caption" {
+		t.Errorf("expected caption 'Test caption', got %v", receivedBody["caption"])
+	}
+	if receivedBody["parse_mode"] != "markdown" {
+		t.Errorf("expected parse_mode 'markdown', got %v", receivedBody["parse_mode"])
+	}
+}
+
+func TestSendMediaJSON_Video(t *testing.T) {
+	var receivedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true,"result":{"message_id":124}}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	err := sendMediaJSON(logger, server.URL, -100123456, nil, "https://example.com/video.mp4", "video", "video", "Video caption", "html", true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedBody["chat_id"].(float64) != -100123456 {
+		t.Errorf("expected chat_id -100123456, got %v", receivedBody["chat_id"])
+	}
+	if receivedBody["video"] != "https://example.com/video.mp4" {
+		t.Errorf("expected video URL, got %v", receivedBody["video"])
+	}
+	if receivedBody["caption"] != "Video caption" {
+		t.Errorf("expected caption, got %v", receivedBody["caption"])
+	}
+	if receivedBody["disable_notification"] != true {
+		t.Errorf("expected disable_notification true, got %v", receivedBody["disable_notification"])
+	}
+	if receivedBody["protect_content"] != true {
+		t.Errorf("expected protect_content true, got %v", receivedBody["protect_content"])
+	}
+}
+
+func TestSendMediaJSON_Sticker_NoCaptionOrParseMode(t *testing.T) {
+	var receivedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true,"result":{"message_id":125}}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	err := sendMediaJSON(logger, server.URL, 12345, nil, "CAACAgIAAxkBAAI", "sticker", "sticker", "This should be ignored", "markdown", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedBody["sticker"] != "CAACAgIAAxkBAAI" {
+		t.Errorf("expected sticker file_id, got %v", receivedBody["sticker"])
+	}
+	if _, ok := receivedBody["caption"]; ok {
+		t.Error("sticker should not have caption")
+	}
+	if _, ok := receivedBody["parse_mode"]; ok {
+		t.Error("sticker should not have parse_mode")
+	}
+}
+
+func TestSendMediaJSON_WithThreadID(t *testing.T) {
+	var receivedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true,"result":{"message_id":126}}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	threadID := int64(42)
+	err := sendMediaJSON(logger, server.URL, 12345, &threadID, "https://example.com/doc.pdf", "document", "document", "Doc caption", "html", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedBody["message_thread_id"].(float64) != 42 {
+		t.Errorf("expected message_thread_id 42, got %v", receivedBody["message_thread_id"])
+	}
+	if receivedBody["document"] != "https://example.com/doc.pdf" {
+		t.Errorf("expected document URL, got %v", receivedBody["document"])
+	}
+}
+
+func TestSendMediaJSON_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"ok":false,"error_code":400,"description":"Bad Request: wrong file identifier/HTTP URL specified"}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	err := sendMediaJSON(logger, server.URL, 12345, nil, "invalid_url", "photo", "photo", "", "", false, false)
+	if err == nil {
+		t.Fatal("expected error for API error response")
+	}
+	if !strings.Contains(err.Error(), "non-OK response") {
+		t.Errorf("expected non-OK response error, got: %v", err)
+	}
+}
+
+func TestSendMediaMultipart_Photo(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test-photo-*.jpg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Write([]byte("fake jpeg data"))
+	tmpFile.Close()
+
+	var receivedFields map[string]string
+	var receivedFileName string
+	var receivedFileField string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil {
+			t.Fatalf("error parsing content type: %v", err)
+		}
+		if !strings.HasPrefix(mediaType, "multipart/") {
+			t.Fatalf("expected multipart content type, got %s", mediaType)
+		}
+
+		receivedFields = make(map[string]string)
+		reader := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("error reading part: %v", err)
+			}
+			data, _ := io.ReadAll(part)
+			if part.FileName() != "" {
+				receivedFileName = part.FileName()
+				receivedFileField = part.FormName()
+			} else {
+				receivedFields[part.FormName()] = string(data)
+			}
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true,"result":{"message_id":127}}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	err = sendMediaMultipart(logger, server.URL, 12345, nil, tmpFile.Name(), "photo", "photo", "Upload caption", "markdown", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedFileField != "photo" {
+		t.Errorf("expected file field 'photo', got %q", receivedFileField)
+	}
+	if receivedFileName != filepath.Base(tmpFile.Name()) {
+		t.Errorf("expected filename %q, got %q", filepath.Base(tmpFile.Name()), receivedFileName)
+	}
+	if receivedFields["chat_id"] != "12345" {
+		t.Errorf("expected chat_id '12345', got %q", receivedFields["chat_id"])
+	}
+	if receivedFields["caption"] != "Upload caption" {
+		t.Errorf("expected caption 'Upload caption', got %q", receivedFields["caption"])
+	}
+	if receivedFields["parse_mode"] != "markdown" {
+		t.Errorf("expected parse_mode 'markdown', got %q", receivedFields["parse_mode"])
+	}
+}
+
+func TestSendMediaMultipart_WithThreadID(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test-video-*.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Write([]byte("fake video data"))
+	tmpFile.Close()
+
+	var receivedFields map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, params, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		receivedFields = make(map[string]string)
+		reader := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("error reading part: %v", err)
+			}
+			if part.FileName() == "" {
+				data, _ := io.ReadAll(part)
+				receivedFields[part.FormName()] = string(data)
+			} else {
+				io.ReadAll(part)
+			}
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true,"result":{"message_id":128}}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	threadID := int64(99)
+	err = sendMediaMultipart(logger, server.URL, -100999, &threadID, tmpFile.Name(), "video", "video", "Thread video", "html", true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedFields["chat_id"] != "-100999" {
+		t.Errorf("expected chat_id '-100999', got %q", receivedFields["chat_id"])
+	}
+	if receivedFields["message_thread_id"] != "99" {
+		t.Errorf("expected message_thread_id '99', got %q", receivedFields["message_thread_id"])
+	}
+	if receivedFields["caption"] != "Thread video" {
+		t.Errorf("expected caption 'Thread video', got %q", receivedFields["caption"])
+	}
+	if receivedFields["disable_notification"] != "true" {
+		t.Errorf("expected disable_notification 'true', got %q", receivedFields["disable_notification"])
+	}
+	if receivedFields["protect_content"] != "true" {
+		t.Errorf("expected protect_content 'true', got %q", receivedFields["protect_content"])
+	}
+}
+
+func TestSendMediaMultipart_Sticker_NoCaptionOrParseMode(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test-sticker-*.webp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Write([]byte("fake webp data"))
+	tmpFile.Close()
+
+	var receivedFields map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, params, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		receivedFields = make(map[string]string)
+		reader := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("error reading part: %v", err)
+			}
+			if part.FileName() == "" {
+				data, _ := io.ReadAll(part)
+				receivedFields[part.FormName()] = string(data)
+			} else {
+				io.ReadAll(part)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true,"result":{"message_id":129}}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	err = sendMediaMultipart(logger, server.URL, 12345, nil, tmpFile.Name(), "sticker", "sticker", "Ignored caption", "markdown", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := receivedFields["caption"]; ok {
+		t.Error("sticker should not have caption field")
+	}
+	if _, ok := receivedFields["parse_mode"]; ok {
+		t.Error("sticker should not have parse_mode field")
+	}
+}
+
+func TestSendMediaMultipart_FileNotFound(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	err := sendMediaMultipart(logger, "http://localhost", 12345, nil, "/nonexistent/file.jpg", "photo", "photo", "", "", false, false)
+	if err == nil {
+		t.Fatal("expected error for non-existent file")
+	}
+	if !strings.Contains(err.Error(), "error opening file") {
+		t.Errorf("expected file open error, got: %v", err)
+	}
+}
+
+func TestSendMediaMultipart_APIError(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test-error-*.jpg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Write([]byte("data"))
+	tmpFile.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		w.Write([]byte(`{"ok":false,"error_code":413,"description":"Request Entity Too Large"}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	err = sendMediaMultipart(logger, server.URL, 12345, nil, tmpFile.Name(), "photo", "photo", "", "", false, false)
+	if err == nil {
+		t.Fatal("expected error for 413 response")
+	}
+	if !strings.Contains(err.Error(), "non-OK response") {
+		t.Errorf("expected non-OK response error, got: %v", err)
+	}
+}
+
+func TestCallTelegramAPI_SendMessage(t *testing.T) {
+	var receivedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/sendMessage") {
+			t.Errorf("expected path to end with /sendMessage, got %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true,"result":{"message_id":130}}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	msg := TelegramMessage{
+		ChatID:    12345,
+		Text:      "Hello",
+		ParseMode: "markdown",
+	}
+
+	serverURL := strings.TrimPrefix(server.URL, "http://")
+	originalURL := "https://api.telegram.org/bot"
+	_ = originalURL
+	_ = serverURL
+
+	err := callTelegramAPI(logger, "testtoken", "sendMessage", msg)
+	if err != nil {
+		if strings.Contains(err.Error(), "connection refused") {
+			t.Skip("cannot test against real Telegram API without token")
+		}
+	}
+}
+
+func TestSendMedia_URLDetection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if payload["photo"] != "https://example.com/image.jpg" {
+			t.Errorf("expected photo URL, got %v", payload["photo"])
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true,"result":{"message_id":131}}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	err := sendMediaJSON(logger, server.URL, 12345, nil, "https://example.com/image.jpg", "photo", "photo", "", "", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSendMediaJSON_AllMediaTypes(t *testing.T) {
+	tests := []struct {
+		mediaType string
+		fieldName string
+		media     string
+	}{
+		{"photo", "photo", "https://example.com/photo.jpg"},
+		{"video", "video", "https://example.com/video.mp4"},
+		{"audio", "audio", "https://example.com/audio.mp3"},
+		{"document", "document", "https://example.com/doc.pdf"},
+		{"animation", "animation", "https://example.com/anim.gif"},
+		{"voice", "voice", "https://example.com/voice.ogg"},
+		{"sticker", "sticker", "CAACAgIAAxkBAAI"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mediaType, func(t *testing.T) {
+			var receivedBody map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				json.Unmarshal(body, &receivedBody)
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"ok":true,"result":{"message_id":200}}`))
+			}))
+			defer server.Close()
+
+			logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+			err := sendMediaJSON(logger, server.URL, 12345, nil, tt.media, tt.fieldName, tt.mediaType, "caption", "html", false, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if receivedBody[tt.fieldName] != tt.media {
+				t.Errorf("expected %s=%q, got %v", tt.fieldName, tt.media, receivedBody[tt.fieldName])
+			}
+
+			if tt.mediaType == "sticker" {
+				if _, ok := receivedBody["caption"]; ok {
+					t.Error("sticker should not have caption")
+				}
+			} else {
+				if receivedBody["caption"] != "caption" {
+					t.Errorf("expected caption for %s, got %v", tt.mediaType, receivedBody["caption"])
+				}
+			}
+		})
+	}
+}
+
+func TestSendMediaJSON_EmptyCaption(t *testing.T) {
+	var receivedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true,"result":{"message_id":201}}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	err := sendMediaJSON(logger, server.URL, 12345, nil, "https://example.com/photo.jpg", "photo", "photo", "", "", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := receivedBody["caption"]; ok {
+		t.Error("empty caption should not be included in payload")
+	}
+	if _, ok := receivedBody["parse_mode"]; ok {
+		t.Error("empty parse_mode should not be included in payload")
+	}
+}
+
+func TestValidMediaTypes(t *testing.T) {
+	expected := map[string]string{
+		"photo":     "sendPhoto",
+		"video":     "sendVideo",
+		"audio":     "sendAudio",
+		"document":  "sendDocument",
+		"animation": "sendAnimation",
+		"voice":     "sendVoice",
+		"sticker":   "sendSticker",
+	}
+
+	for mediaType, method := range expected {
+		if validMediaTypes[mediaType] != method {
+			t.Errorf("validMediaTypes[%q] = %q, want %q", mediaType, validMediaTypes[mediaType], method)
+		}
+	}
+
+	invalidTypes := []string{"gif", "file", "image", "mp3", "mp4", ""}
+	for _, invalid := range invalidTypes {
+		if _, ok := validMediaTypes[invalid]; ok {
+			t.Errorf("expected %q to be invalid media type", invalid)
+		}
+	}
+}
+
+func TestMediaFieldName(t *testing.T) {
+	for mediaType := range validMediaTypes {
+		if _, ok := mediaFieldName[mediaType]; !ok {
+			t.Errorf("missing mediaFieldName entry for %q", mediaType)
+		}
+	}
+}
+
+func TestSendMediaMultipart_NegativeChatID(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "test-neg-*.jpg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Write([]byte("data"))
+	tmpFile.Close()
+
+	var receivedFields map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, params, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		receivedFields = make(map[string]string)
+		reader := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("error reading part: %v", err)
+			}
+			if part.FileName() == "" {
+				data, _ := io.ReadAll(part)
+				receivedFields[part.FormName()] = string(data)
+			} else {
+				io.ReadAll(part)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true,"result":{"message_id":132}}`))
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	err = sendMediaMultipart(logger, server.URL, -1001234567890, nil, tmpFile.Name(), "photo", "photo", "", "", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedFields["chat_id"] != "-1001234567890" {
+		t.Errorf("expected chat_id '-1001234567890', got %q", receivedFields["chat_id"])
+	}
+}


### PR DESCRIPTION
Adds media upload support (photos, videos, audio, documents, animations, voice, stickers).

The new `media` input takes a local file path, HTTP URL, or Telegram file_id. Pair it with `media-type` to pick the right API method. When media is set, `message` becomes the caption (except stickers, which don't support captions).

Backwards compatible -> existing workflows that only use `message` are unaffected.